### PR TITLE
Mobile fixes, SondeHub V1 Support, Filter by type

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -454,14 +454,6 @@ header .search form input[type='submit'] {
     border: 1px solid #5E5E5E;
 }
 
-#main .portrait .row .data .vbutton {
-    top: 50px !important;
-}
-
-#main .portrait .row .data .sbutton {
-    top: 80px !important;
-}
-
 #main .row .data img {
     position: absolute;
     z-index: 2;
@@ -842,7 +834,7 @@ header .search form input[type='submit'] {
     }
     #main .data .left {
         float: left;
-        width: 160px;
+        width: 80%;
         padding-left: 5px;
     }
     #main .data dl > dt {
@@ -878,7 +870,7 @@ header .search form input[type='submit'] {
     }
     #main .data .left {
         float: left;
-        width: 60%;
+        width: 55%;
         padding-left: 5px;
     }
     #main .data .right {

--- a/css/main.css
+++ b/css/main.css
@@ -323,9 +323,6 @@ header .search form input[type='submit'] {
     border-left: 5px solid #ccc;
 }
 
-#main .vehicle0 .header {
-    border-top: 1px solid #33b5e5;
-}
 #main .header.empty {
     text-align: center;
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -94,17 +94,14 @@
                 You can find the status of the SondeHub Database on the <a href="https://sondehub.org/go/status" target="_blank" rel="noopener">SondeHub Dashboard</a>.<br/>
                 You can view outages of the SondeHub Database at <a href="https://sondehub.statuspage.io/" target="_blank" rel="noopener">SondeHub Status</a>.
 
+                <h4>Info</h4>
+                This site uses data from the <a href="https://github.com/projecthorus/sondehub-infra/wiki" target="_blank" rel="noopener">SondeHub v2</a> database, which will remove the radiosonde  
+                load from the Habitat tracking database.
+                <br/><br/>
+                Chase Cars can show up on the map using this tracker's chase-car features (look for the car icon at top-right) 
+                or upload their position from <a href="https://github.com/projecthorus/chasemapper" target="_blank" rel="noopener">Chasemapper</a> or <a href="https://github.com/dl9rdz/rdz_ttgo_sonde" target="_blank" rel="noopener">rdzTTGOsonde</a>.
+
             </div>
-            <br/>
-            <h2>Under Beta!</h2>
-            <hr/>
-            This site uses data from the <a href="https://github.com/projecthorus/sondehub-infra/wiki" target="_blank" rel="noopener">SondeHub v2</a> database, which will remove the radiosonde  
-            load from the Habitat tracking database. We are still working to being this tracker up to feature-parity with the previous
-            tracker, so some features like filtering by type are still in-progress.
-            <br/><br/>
-            Chase Cars can show up on the map using this tracker's chase-car features (look for the car icon at top-right) 
-            or upload their position from <a href="https://github.com/projecthorus/chasemapper" target="_blank" rel="noopener">Chasemapper</a> or <a href="https://github.com/dl9rdz/rdz_ttgo_sonde" target="_blank" rel="noopener">rdzTTGOsonde</a>.
-            <br/><br/>
             <h2>Contribute</h2>
             <hr/>
             <p>
@@ -366,12 +363,6 @@
     <script type="text/javascript" language="javascript" src="js/Leaflet.fullscreen.min.js"></script>
     <script type="text/javascript" language="javascript" src="js/L.Terminator.js"></script>
     <script src="https://xc5dqkj2cgb1.statuspage.io/embed/script.js" async defer></script>
-    <script type="text/javascript" language="javascript" src="js/mobile.js"></script>
-    <script type="text/javascript" language="javascript" src="js/rbush.js"></script>
-    <script>var module = {};</script>
-    <script src="js/leaflet.canvas-markers.js"></script>
-    <script>module.exports(L);</script>
-    <script type="text/javascript" language="javascript" src="js/pwa.js"></script>
     <!--
     <script type="text/javascript" language="javascript" src="js/iscroll.js"></script>
     <script type="text/javascript" language="javascript" src="js/jquery-1.12.4-min.js"></script>
@@ -379,5 +370,12 @@
     <script type="text/javascript" language="javascript" src="js/tracker.js"></script>
     <script type="text/javascript" language="javascript" src="js/app.js"></script>
     -->
+    <script type="text/javascript" language="javascript" src="js/mobile.js"></script>
+    <script type="text/javascript" language="javascript" src="js/rbush.js"></script>
+    <script>var module = {};</script>
+    <script src="js/leaflet.canvas-markers.js"></script>
+    <script>module.exports(L);</script>
+    <script type="text/javascript" language="javascript" src="js/pwa.js"></script>
+    
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,8 @@
                 <h4>Info</h4>
                 This site uses data from the <a href="https://github.com/projecthorus/sondehub-infra/wiki" target="_blank" rel="noopener">SondeHub v2</a> database, which will remove the radiosonde  
                 load from the Habitat tracking database.
-                <br/><br/>
+
+                <h4>Chase Cars</h4>
                 Chase Cars can show up on the map using this tracker's chase-car features (look for the car icon at top-right) 
                 or upload their position from <a href="https://github.com/projecthorus/chasemapper" target="_blank" rel="noopener">Chasemapper</a> or <a href="https://github.com/dl9rdz/rdz_ttgo_sonde" target="_blank" rel="noopener">rdzTTGOsonde</a>.
 

--- a/js/tracker.js
+++ b/js/tracker.js
@@ -1219,23 +1219,30 @@ function updateVehicleInfo(vcallsign, newPosition) {
     callsign_list = callsign_list.join(", ");
   }
 
+  //desktop
   var a    = '<div class="header">' +
            '<span>' + sonde_type + vcallsign + ' <i class="icon-target"></i></span>' +
-           //'<span>' + vcallsign + ' <i class="icon-target"></i></span>' +
            '<canvas class="graph"></canvas>' +
            '<i class="arrow"></i></div>' +
-           '<div class="data" style="min-height:' + (vehicle.image_src_size[1]+95) + 'px">' +
+           '<div class="data">' +
            '<img class="'+((vehicle.vehicle_type=="car")?'car':'')+'" src="'+image+'" />' +
            '<span class="vbutton path '+((vehicle.polyline_visible) ? 'active' : '')+'" data-vcallsign="'+vcallsign+'"' + ' style="top:'+(vehicle.image_src_size[1]+55)+'px">Path</span>' +
            ((vehicle.vehicle_type!="car") ? '<span class="sbutton" onclick="shareVehicle(\'' + vcallsign + '\')" style="top:'+(vehicle.image_src_size[1]+85)+'px">Share</span>' : '') +
            ((vehicle.vehicle_type!="car") ? '<span class="sbutton" onclick="window.open(\'https://sondehub.org/card/' + vcallsign + '\')" style="top:'+(vehicle.image_src_size[1]+115)+'px">Card</span>' : '') +
-           ((vcallsign in hysplit) ? '<span class="vbutton hysplit '+((hysplit[vcallsign].getMap()) ? 'active' : '')+'"' +
-                ' data-vcallsign="'+vcallsign+'" style="top:'+(vehicle.image_src_size[1]+55+21+10)+'px">HYSPLIT</span>' : '') +
-           ((vcallsign.substr(0, 6) in ssdv) ? '<a class="vbutton active" href="//ssdv.habhub.org/' + vcallsign.substr(0, 6) + '"' +
-                ' target="_blank" style="top:'+(vehicle.image_src_size[1]+55+((vcallsign in hysplit) ? 42 : 21)+10)+'px">SSDV</a>' : '') +
            '<div class="left">' +
            '<dl>';
-  // end
+  //mobile
+  var aa    = '<div class="header">' +
+           '<span>' + sonde_type + vcallsign + ' <i class="icon-target"></i></span>' +
+           '<canvas class="graph"></canvas>' +
+           '<i class="arrow"></i></div>' +
+           '<div class="data">' +
+           '<img class="'+((vehicle.vehicle_type=="car")?'car':'')+'" src="'+image+'" />' +
+           '<span class="vbutton path '+((vehicle.polyline_visible) ? 'active' : '')+'" data-vcallsign="'+vcallsign+'"' + ' style="top:55px">Path</span>' +
+           ((vehicle.vehicle_type!="car") ? '<span class="sbutton" onclick="shareVehicle(\'' + vcallsign + '\')" style="top:85px">Share</span>' : '') +
+           ((vehicle.vehicle_type!="car") ? '<span class="sbutton" onclick="window.open(\'https://sondehub.org/card/' + vcallsign + '\')" style="top:115px">Card</span>' : '') +
+           '<div class="left">' +
+           '<dl>';
   var b    = '</dl>' +
            '</div>' + // right
            '</div>' + // data
@@ -1268,7 +1275,7 @@ function updateVehicleInfo(vcallsign, newPosition) {
            '';
 
   // update html
-  $('.portrait .vehicle'+vehicle.uuid).html(a + p + b);
+  $('.portrait .vehicle'+vehicle.uuid).html(aa + p + b);
   $('.landscape .vehicle'+vehicle.uuid).html(a + l + b);
 
   // redraw canvas

--- a/js/tracker.js
+++ b/js/tracker.js
@@ -2742,6 +2742,10 @@ function refreshSingleOld(serial) {
         }
     }
 
+    if (ajax_inprogress_old == serial) {
+        return;
+    }
+
     document.getElementById("timeperiod").disabled = true;
   
     var data_url = "https://api.v2.sondehub.org/sonde/" + encodeURIComponent(serial); 
@@ -2760,7 +2764,7 @@ function refreshSingleOld(serial) {
             if (data[i].hasOwnProperty('subtype')) {
               if (data[i].subtype != "SondehubV1") {
                 var dataTempEntry = {};
-                var station = data[i].uploader_callsign
+                var station = data[i].uploader_callsign;
                 dataTempEntry.callsign = {};
                 dataTempEntry.callsign[station] = {};
                 dataTempEntry.callsign[station].snr = data[i].snr;
@@ -2802,13 +2806,38 @@ function refreshSingleOld(serial) {
                 if (data[i].pressure) {
                     dataTempEntry.data.pressure = data[i].pressure;
                 }
-                dataTemp.push(dataTempEntry)
+                dataTemp.push(dataTempEntry);
+              } else {
+                var dataTempEntry = {};
+                var station = data[i].uploader_callsign;
+                dataTempEntry.callsign = {};
+                dataTempEntry.callsign[station] = {};
+                dataTempEntry.gps_alt = parseFloat(data[i].alt);
+                dataTempEntry.gps_lat = parseFloat(data[i].lat);
+                dataTempEntry.gps_lon = parseFloat(data[i].lon);
+                dataTempEntry.gps_time = data[i].time_received;
+                dataTempEntry.server_time = data[i].time_received;
+                dataTempEntry.vehicle = data[i].serial;
+                dataTempEntry.position_id = data[i].serial + "-" + data[i].time_received;
+                dataTempEntry.data = {};
+                if (data[i].humidity) {
+                    dataTempEntry.data.humidity = parseFloat(data[i].humidity);
+                }
+                if (data[i].temp) {
+                    dataTempEntry.data.temperature_external = parseFloat(data[i].temp);
+                }
+                dataTemp.push(dataTempEntry);
               }
             }
           }
           response.positions.position = dataTemp;
           response.fetch_timestamp = Date.now();
-          update(response, "old");
+          if (response.positions.position.length == 0) {
+            update(response);
+          } else {
+            update(response, "old");
+          }
+          
       }
     });
 }


### PR DESCRIPTION
**Features**
- We can now display sondes which were imported into the database from V1.
- We can now filter by type by entering one of the following in the search box:
`["RS92", "RS92-SGP", "RS92-NGP", "RS41", "RS41-SG", "RS41-SGP", "RS41-SGM", "DFM", "DFM06", "DFM09", "DFM17", "M10", "M20", "iMet-4", "iMet-54", "LMS6", "LMS6-400", "LMS6-1680", "iMS-100", "MRZ"]`

**Fixes**
- Formatting on mobile
- Updated webpage