### PR TITLE
Fix Chase cars icons not showing on map

### DIFF
--- a/js/tracker.js
+++ b/js/tracker.js
@@ -2563,8 +2563,16 @@ var marker_rotate_setup = function(marker, image_src) {
     marker.rotated = false;
     if(image_src in icon_cache) {
         marker.iconImg = icon_cache[image_src];
-        marker.setCourse(90);
-        marker.setLatLng(marker.getLatLng());
+        
+        if (marker.iconImg.complete){
+            marker.setCourse(90);
+            marker.setLatLng(marker.getLatLng());
+        }else{
+            marker.iconImg.addEventListener("load", function() {
+                marker.setCourse(90);
+                marker.setLatLng(marker.getLatLng());
+            })
+        }
     }
     else {
         marker.iconImg = new Image();


### PR DESCRIPTION
This PR fixes #244 issue.
When there are multiple chase cars with the same color at site load, since the HTML img element is stored in icon_cache before the img loads, accessing it right away and making a canvas will not work since the img hasn’t loaded yet. So i added a listener for load.