### PR TITLE
Add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+RUN apk add --no-cache python3 openjdk11 sed git
+
+WORKDIR /app
+ADD . .
+
+RUN sh build.sh
+
+ENTRYPOINT ["python3", "serve.py"]
+EXPOSE 8000


### PR DESCRIPTION
Hey!
Here's a small change to add a Dockerfile to test locally in a clean and environment-agnostic manner. 

To use, you just need to build and run it, 
**To build**
```
docker build -t sondehub-tracker .
```

**And, to run**
```
docker run --rm -p 8000:8000 --name sondehub-tracker sondehub
```
If you'd like to run in the background and not terminate after you exit your terminal, replace `--rm` with `-d`.