### PR TITLE
Add a link to view a sonde on Google Maps on PCs

### DIFF
--- a/js/tracker.js
+++ b/js/tracker.js
@@ -1582,7 +1582,9 @@ function updateVehicleInfo(vcallsign, newPosition) {
                     roundNumber(newPosition.gps_lat, 5) + ', ' + roundNumber(newPosition.gps_lon, 5) +'</a>' +
                     ' <i class="icon-location"></i>';
   } else {
-      coords_text = roundNumber(newPosition.gps_lat, 5) + ', ' + roundNumber(newPosition.gps_lon, 5);
+      coords_text = '<a id="launch_mapapp" href="https://www.google.com/maps/search/?api=1&query='+newPosition.gps_lat+','+newPosition.gps_lon+'" target="_blank" rel="noopener noreferrer">' +
+          roundNumber(newPosition.gps_lat, 5) + ', ' + roundNumber(newPosition.gps_lon, 5) +'</a>' +
+          ' <i class="icon-location"></i>';
   }
 
   // format altitude strings


### PR DESCRIPTION
Not sure if this was intended to not be added, but I find this feature useful when I'm wanting to look for directions when determining if I want to chase a sonde if it landed nearby.

![image](https://user-images.githubusercontent.com/8205849/168955119-90b6cf8c-083b-404c-be9d-3a5b6f55ee4b.png)
The UI is the exact same as on other platforms, however when clicking on the link you are taken to Google Maps in a new tab.

![image](https://user-images.githubusercontent.com/8205849/168955231-1f89cd98-d56c-44fe-ab0e-923bc5a48ff5.png)

I'm not sure if it's possible to assign a marker with a name on it like Android can, but this is a simple change to enable clickable coordinates on the desktop