### PR TITLE
README.md link typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fork of [habitat-mobile-tracker](https://github.com/rossengeorgiev/habitat-mob
 ![mobile tracker screenshot](resources/mobiletracker-screencap.png "mobile tracker screenshot")
 
 A webapp for tracking radiosondes. Works an desktop and mobile devices.
-The SondeHub tracker is a continuation of the [HabHub Tracker]](http://tracker.habhub.org).
+The SondeHub tracker is a continuation of the [HabHub Tracker](http://tracker.habhub.org).
 
 ## Features
 


### PR DESCRIPTION
Fixed the markdown typo of the HabHub Tracker link in the `README.md` file