### PR TITLE
Change balloon color selection to be stable per-balloon

### DIFF
--- a/js/tracker.js
+++ b/js/tracker.js
@@ -74,7 +74,6 @@ var manual_pan = false;
 
 var car_index = 0;
 var car_colors = ["blue", "red", "green", "yellow", "teal", "purple"];
-var balloon_index = 0;
 var balloon_colors_name = ["red", "blue", "green", "purple", "orange", "cyan"];
 var balloon_colors = ["#f00", "blue", "green", "#c700e6", "#ff8a0f", "#0fffca"];
 
@@ -831,7 +830,6 @@ function clean_refresh(text, force, history_step) {
     }
 
     car_index = 0;
-    balloon_index = 0;
     nyan_color_index = 0;
     stopFollow(force);
 
@@ -3088,7 +3086,11 @@ function addPosition(position) {
             marker.addTo(map);
         } else {
             vehicle_type = "balloon";
-            color_index = balloon_index++ % balloon_colors.length;
+            let colorHash = 0;
+            for (let i = 0; i < vcallsign.length; i++){
+                colorHash += vcallsign.charCodeAt(i);
+            }
+            color_index = colorHash % balloon_colors.length;
 
             if(wvar.nena){
                 // All the balloon are red.


### PR DESCRIPTION
When viewing SondeHub, a user will see some number of balloons in their view. Balloons are colored with a few different colors, to make it easy to tell them apart.

Currently, the color is selected by iterating through all the balloons, one by one, and each balloon gets a color from the list of colors, sequentially. Because balloons are iterated through in a non-deterministic manner (such that inserting or removing one balloon from the set will change the outcome of the others), viewing the set of balloons multiple times will result in the colors becoming re-shuffled. Therefore, refreshing the page, or viewing it on multiple devices (including viewing the site alongside a friend) will mean the same balloon will appear with different colors on different viewings.

This PR changes the logic such that the color is chosen by a hash of the callsign for the balloon, meaning that a given balloon will always show up with the same color for all viewers on all viewings. Because the balloon_index variable is no longer used, I have removed it.