### PR TITLE
Fix callsign null check

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -667,7 +667,7 @@ $(window).ready(function() {
             if(currentPosition && currentPosition.marker) map.addLayer(currentPosition.marker);
         // turning the switch on
         } else {
-            if(callsign.length == null || callsign.length < 3) { alert('Please enter a valid callsign, at least 3 characters'); return; }
+            if(callsign == null || callsign.length < 3) { alert('Please enter a valid callsign, at least 3 characters'); return; }
             if(!callsign.match(/^[a-zA-Z0-9\_\-]+$/)) { alert('Invalid characters in callsign (use only a-z,0-9,-,_)'); return; }
 
             field.attr('disabled','disabled');


### PR DESCRIPTION
In the Chase Mode section, if "Enable" is toggled before a callsign is first set, then an exception occurs and the user gets no feedback:

> Uncaught TypeError: callsign is null

This only happens if a callsign has never been set, and therefore no `callsign` value exists in local storage.

I've fixed the null check so that the user gets an alert popup when no callsign has been set.