### PR TITLE
Fix PWA caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.log
 /index.html
+/service-worker.js
 /js/version.json
 cache.manifest
 tiles/

--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -4,6 +4,6 @@ To get a copy of the code and run a test web server:
 
 1. [Fork the repository](https://github.com/projecthorus/sondehub-tracker/fork) by visiting [https://github.com/projecthorus/sondehub-tracker/fork](https://github.com/projecthorus/sondehub-tracker/fork).
 2. Clone the repository with your git tool of choice.
-3. Run `build.sh` to generate `index.html` and `js/version.json`.
+3. Run `build.sh` to generate `index.html`, `service-worker.js`, and `js/version.json`.
 4. Run `python serve.py` to run a simple web server to (This requires python 3.x)
 5. Visit [http://localhost:8000](http://localhost:8000) to view the local version of the server!

--- a/build.sh
+++ b/build.sh
@@ -15,4 +15,8 @@ echo -n "Generating index.html... "
 sed -e "s/{VER}/$VERSION/" -e "s/{BUILD_DATE}/$BUILD_DATE/" index.template.html > index.html
 echo "Done!"
 
+echo -n "Generating service-worker.js... "
+sed -e "s/{VER}/$VERSION/" service-worker.template.js > service-worker.js
+echo "Done!"
+
 echo "Build version: $VERSION Build date: $BUILD_DATE"

--- a/index.template.html
+++ b/index.template.html
@@ -50,7 +50,7 @@
         <script type="text/javascript" language="javascript" src="js/pwa.js?v={VER}"></script>
     
     </head>
-    <body data-version="{VER}" data-build-date="{BUILD_DATE}">
+    <body data-version="{VER}">
 
     <div id="loading">
         <div>
@@ -150,9 +150,9 @@
                 <a href="https://github.com/projecthorus/sondehub-tracker" target="_blank" rel="noopener">github/sondehub-tracker</a>.
                 Bug reports, suggestions and pull requests are welcome. A huge thanks to RGP for developing the mobile tracker that this site is based on.
                 <br/><br/>
-                Tracker Revision: <span class="r" id="build_version"></span>
+                Tracker Revision: <span class="r">{VER}</span>
                 <br/>
-                Build Date: <span class="r" id="build_date"></span>
+                Build Date: <span class="r">{BUILD_DATE}</span>
 
             </p>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -493,10 +493,6 @@ $(window).ready(function() {
         updateTime(new Date());
     }, 1000);
 
-    // Update Tracker version info
-    $('#build_version').text(document.body.dataset.version);
-    $('#build_date').text(document.body.dataset.buildDate);
-
     // resize elements if needed
     checkSize();
 

--- a/service-worker.template.js
+++ b/service-worker.template.js
@@ -1,6 +1,6 @@
 self.addEventListener('install', function(event) {
     event.waitUntil(
-        caches.open(document.body.dataset.version).then(function(cache) {
+        caches.open("{VER}").then(function(cache) {
             return cache.addAll(
                 [
                     '/css/base.css',


### PR DESCRIPTION
In #341 I made `service-worker.js` static, but I realized after the fact that this will likely break PWA updating, because devices check for updates by looking for changes in `manifest.json` or `service-worker.js`.

Here I've switched back to a templated `service-worker.js`, which is generated from `service-worker.template.js`.

Additionally, I realized that there wasn't match point having the now-static `app.js` pull the version information from `index.html` and dump it back in, so I moved that information directly into `index.html`.