### PR TITLE
Add horizon ring hide toggle

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -272,6 +272,13 @@
                 </div>
             </div>
             <div class="row option">
+                <span><b>Hide Horizon Rings</b></span>
+                <div class="switch off" id="sw_hide_horizon">
+                    <span class="thumb"></span>
+                    <input type="checkbox" id="opt_hide_horizon">
+                </div>
+            </div>
+            <div class="row option">
                 <span><b>Hide Titles</b></span>
                 <div class="switch off" id="sw_hide_titles">
                     <span class="thumb"></span>

--- a/js/app.js
+++ b/js/app.js
@@ -809,6 +809,7 @@ $(window).ready(function() {
         "#sw_hide_chase",
         "#sw_hide_timebox",
         "#sw_hilight_vehicle",
+        '#sw_hide_horizon',
         '#sw_hide_titles',
         '#sw_layers_launches',
         '#sw_selective_sidebar',
@@ -904,6 +905,14 @@ $(window).ready(function() {
                 } else {
                     elm.addClass('present').show();
                     $('#lookanglesbox').css({top:'40px'});
+                }
+                break;
+            case "opt_hide_horizon":
+                if(on) {
+                    hideHorizonRings();
+                }
+                else {
+                    updateHorizonVisibility();
                 }
                 break;
             case "opt_hide_titles":

--- a/js/sondehub.js
+++ b/js/sondehub.js
@@ -998,25 +998,29 @@ function load() {
     map.on('zoomend', function() {
         sub_to_nearby_sondes();
         //do check for horizon labels
-        for (key in vehicles) {
-            if (vehicles[key]["vehicle_type"] == "balloon") {
-                if (vehicles[key]["horizon_circle"]["_map"]) 
-                {
-                    try {
-                        var zoom = map.getZoom();
-                        var horizonzoom = (Math.abs(Math.log(vehicles[key]["horizon_circle"].getRadius()/2000000)/0.75));
-                        var subhorizonzoom = (Math.abs(Math.log(vehicles[key]["subhorizon_circle"].getRadius()/2000000)/0.75));
-                        if (horizonzoom > zoom) {
-                            map.removeLayer(vehicles[key]["horizon_circle_title"]);
-                        } else {
-                            map.addLayer(vehicles[key]["horizon_circle_title"]);
-                        }
-                        if (subhorizonzoom > zoom) {
-                            map.removeLayer(vehicles[key]["subhorizon_circle_title"]);
-                        } else {
-                            map.addLayer(vehicles[key]["subhorizon_circle_title"]);
-                        }
-                    } catch(e){};
+        if (offline.get("opt_hide_horizon")) {
+            hideHorizonRings();
+        } else {
+            for (key in vehicles) {
+                if (vehicles[key]["vehicle_type"] == "balloon") {
+                    if (vehicles[key]["horizon_circle"]["_map"])
+                    {
+                        try {
+                            var zoom = map.getZoom();
+                            var horizonzoom = (Math.abs(Math.log(vehicles[key]["horizon_circle"].getRadius()/2000000)/0.75));
+                            var subhorizonzoom = (Math.abs(Math.log(vehicles[key]["subhorizon_circle"].getRadius()/2000000)/0.75));
+                            if (horizonzoom > zoom) {
+                                map.removeLayer(vehicles[key]["horizon_circle_title"]);
+                            } else {
+                                map.addLayer(vehicles[key]["horizon_circle_title"]);
+                            }
+                            if (subhorizonzoom > zoom) {
+                                map.removeLayer(vehicles[key]["subhorizon_circle_title"]);
+                            } else {
+                                map.addLayer(vehicles[key]["subhorizon_circle_title"]);
+                            }
+                        } catch(e){};
+                    }
                 }
             }
         }
@@ -5066,6 +5070,7 @@ function updateHorizonVisibility(){
     // (the last selected sonde)
     hideHorizonRings();
 
+    if (offline.get("opt_hide_horizon")) return;
     if (follow_vehicle === null) return;
     if (!vehicles.hasOwnProperty(follow_vehicle)) return;
     if (vehicles[follow_vehicle].vehicle_type != "balloon") return;


### PR DESCRIPTION
Adds a Settings toggle to suppress display of horizon rings.

When enabled, existing horizon ring layers are removed and horizon visibility
updates leave them hidden. When disabled, the current selected-sonde-only horizon
ring behavior is unchanged.

Tested with a locally run server.