### PR TITLE
Support software defaults from the pledges API

### DIFF
--- a/js/sondehub.js
+++ b/js/sondehub.js
@@ -1395,7 +1395,7 @@ function updateZoom() {
     for(x in launches._layers){launches.getLayer(x).setRadius(Math.min(map.getZoom(),8))}
     for(x in receivers){
         var radius = 6;
-        if (receivers[x].name in pledges){
+        if (getReceiverLevel(receivers[x]) !== null){
             radius = radius * 1.3
         }
         
@@ -4513,6 +4513,18 @@ function stopAjax() {
 
 var currentPosition = null;
 
+function getReceiverLevel(receiver) {
+    if (Object.prototype.hasOwnProperty.call(pledges, receiver.name)) {
+        return pledges[receiver.name].icon;
+    }
+
+    if (typeof receiver.software == "string" && receiver.software.startsWith("SondeFox")) {
+        return "bronze";
+    }
+
+    return null;
+}
+
 function updateCurrentPosition(lat, lon) {
     var latlng = new L.LatLng(lat, lon);
 
@@ -4540,20 +4552,21 @@ function updateCurrentPosition(lat, lon) {
 
 function updateReceiverMarker(receiver) {
   var latlng = new L.LatLng(receiver.lat, receiver.lon);
+  var receiverLevel = getReceiverLevel(receiver);
 
 
   // init a marker if the receiver doesn't already have one
   if(!receiver.marker) {
 
-    if (pledges.hasOwnProperty(receiver.name)) {
-        if (pledges[receiver.name].icon == "bronze") {
+    if (receiverLevel !== null) {
+        if (receiverLevel == "bronze") {
             receiver.marker = new L.CircleMarker(latlng, {
                 radius: Math.min(map.getZoom(),6*1.3),
                 fillOpacity: 0.6,
                 color: "#CD7F32",
             });
             receiver.infobox = new L.popup({ autoClose: false, closeOnClick: false, className: "bronze" }).setContent(receiver.description);
-        } else if (pledges[receiver.name].icon == "silver") {
+        } else if (receiverLevel == "silver") {
             receiver.marker = new L.CircleMarker(latlng, {
                 radius: Math.min(map.getZoom(),6*1.3),
                 fillOpacity: 0.6,

--- a/js/sondehub.js
+++ b/js/sondehub.js
@@ -4513,16 +4513,62 @@ function stopAjax() {
 
 var currentPosition = null;
 
+function getPledgeIcon(pledge) {
+    if (pledge === null || typeof pledge != "object" || Array.isArray(pledge)) {
+        return null;
+    }
+
+    if (typeof pledge.icon != "string" || pledge.icon.length === 0) {
+        return null;
+    }
+
+    return pledge.icon;
+}
+
 function getReceiverLevel(receiver) {
-    if (Object.prototype.hasOwnProperty.call(pledges, receiver.name)) {
-        return pledges[receiver.name].icon;
+    if (receiver === null || typeof receiver != "object" || pledges === null ||
+        typeof pledges != "object" || Array.isArray(pledges)) {
+        return null;
     }
 
-    if (typeof receiver.software == "string" && receiver.software.startsWith("SondeFox")) {
-        return "bronze";
+    if (typeof receiver.name == "string" && receiver.name !== "_software" &&
+        Object.prototype.hasOwnProperty.call(pledges, receiver.name)) {
+        var receiverIcon = getPledgeIcon(pledges[receiver.name]);
+        if (receiverIcon !== null) {
+            return receiverIcon;
+        }
     }
 
-    return null;
+    if (typeof receiver.software != "string") {
+        return null;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(pledges, "_software")) {
+        return null;
+    }
+
+    var softwarePledges = pledges._software;
+    if (softwarePledges === null || typeof softwarePledges != "object" || Array.isArray(softwarePledges)) {
+        return null;
+    }
+
+    var matchedPrefix = "";
+    var matchedIcon = null;
+    for (var softwarePrefix in softwarePledges) {
+        if (!Object.prototype.hasOwnProperty.call(softwarePledges, softwarePrefix) ||
+            softwarePrefix.length === 0 || softwarePrefix.length <= matchedPrefix.length ||
+            !receiver.software.startsWith(softwarePrefix)) {
+            continue;
+        }
+
+        var softwareIcon = getPledgeIcon(softwarePledges[softwarePrefix]);
+        if (softwareIcon !== null) {
+            matchedPrefix = softwarePrefix;
+            matchedIcon = softwareIcon;
+        }
+    }
+
+    return matchedIcon;
 }
 
 function updateCurrentPosition(lat, lon) {


### PR DESCRIPTION
## Summary

- Resolve receiver levels from software-prefix defaults supplied by the `/pledges` API instead of hard-coding SondeFox in the tracker.
- Keep existing top-level callsign pledges authoritative, so explicit silver, gold, and future tiers override a software default.
- Use the longest matching valid prefix and preserve ranked receiver sizing after map zoom changes.
- Ignore missing or malformed rule metadata so the current flat API response continues to work unchanged.

## Proposed `/pledges` contract

Keep all existing callsign entries and add one reserved, backward-compatible metadata member:

```json
{
  "KF6DMA-SondeFox": {"icon": "gold"},
  "_software": {
    "SondeFox": {"icon": "bronze"}
  }
}
```

Keys in `_software` are case-sensitive `software_name` prefixes. Exact callsign entries take precedence; otherwise the longest matching prefix supplies the icon.

This additive shape keeps old tracker clients working because they continue to use only exact top-level callsign lookups. It also avoids materializing active callsigns in the API, which could become stale or leak defaults between radiosonde and amateur listeners that share a callsign.

## Rollout

- [x] Add generic tracker support for API-provided software defaults.
- [ ] Confirm the proposed `_software` field with the pledges API owner.
- [ ] Publish `SondeFox -> bronze` from the pledges API.
- [ ] Verify against the deployed API after its five-minute CloudFront cache expires.

The tracker change is safe to deploy before or after the API addition. Until `_software` is present, behavior remains unchanged. Existing tracker clients ignore the additive field.

The pledges handler itself is managed outside this public repository, so this draft defines the consumer contract for backend-owner confirmation. This follows the direction in https://github.com/projecthorus/sondehub-tracker/pull/437#issuecomment-5504652240.

## Testing

- `node --check js/sondehub.js`
- `./build.sh`
- Focused contract assertions for legacy payloads, exact-tier precedence, case-sensitive prefix matching, longest-prefix selection, malformed metadata, and missing software.
- Focused marker assertions for bronze/gold/green styling and ranked radius retention after zoom.